### PR TITLE
Configure Cloudflare Workers deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Create an optimized build in the `dist/` directory:
 npm run build
 ```
 
+## Cloudflare Workers Deployment
+
+This project is configured to deploy to [Cloudflare Workers](https://developers.cloudflare.com/workers/) using Wrangler.
+
+Build and deploy the worker (requires authentication with Cloudflare):
+
+```bash
+npm run deploy
+```
+
+To preview the worker locally with asset serving, use Wrangler's dev server:
+
+```bash
+npx wrangler dev
+```
+
 ## Preview
 
 Preview the production build locally (runs `npm run build` if necessary):

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,9 @@
 import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
 
 export default defineConfig({
   site: 'https://example.com',
+  adapter: cloudflare(),
+  output: 'server',
   integrations: [],
 });

--- a/package.json
+++ b/package.json
@@ -6,9 +6,15 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@astrojs/cloudflare": "^8.0.0",
     "astro": "^4.5.5"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240620.0",
+    "wrangler": "^3.57.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "target": "ESNext",
-    "types": ["astro/client"],
+    "types": ["astro/client", "@cloudflare/workers-types"],
     "strict": true
   },
   "include": ["src"],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developers.cloudflare.com/workers/tools/wrangler/configuration/schema.json",
+  "name": "astro-brochure-site",
+  "main": "./dist/_worker.js",
+  "compatibility_date": "2024-06-01",
+  "assets": {
+    "directory": "./dist/client"
+  },
+  "build": {
+    "command": "npm run build"
+  }
+}


### PR DESCRIPTION
## Summary
- add the Cloudflare adapter and Wrangler tooling for Astro
- configure Wrangler and TypeScript for Workers output and assets
- document deployment workflow for Cloudflare Workers

## Testing
- npm install *(fails: registry access is blocked in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d6cfa42bc08331974052f2743ac10b