### PR TITLE
Ensure Cloudflare deployment finds assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ Create an optimized build in the `dist/` directory:
 npm run build
 ```
 
+## Cloudflare Workers Deployment
+
+This project is configured to deploy to [Cloudflare Workers](https://developers.cloudflare.com/workers/) using Wrangler.
+
+Build and deploy the worker (requires authentication with Cloudflare):
+
+```bash
+npm run deploy
+```
+
+The build step ensures `dist/client` exists with the static assets Wrangler expects, so deploys succeed even when no client bundles are generated.
+
+To preview the worker locally with asset serving, use Wrangler's dev server:
+
+```bash
+npx wrangler dev
+```
+
 ## Preview
 
 Preview the production build locally (runs `npm run build` if necessary):

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,9 @@
 import { defineConfig } from 'astro/config';
+import cloudflare from '@astrojs/cloudflare';
 
 export default defineConfig({
   site: 'https://example.com',
+  adapter: cloudflare(),
+  output: 'server',
   integrations: [],
 });

--- a/package.json
+++ b/package.json
@@ -6,9 +6,16 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "postbuild": "node scripts/postbuild/prepare-worker-assets.mjs",
+    "preview": "astro preview",
+    "deploy": "wrangler deploy"
   },
   "dependencies": {
-    "astro": "^4.5.5"
+    "@astrojs/cloudflare": "^8.1.0",
+    "astro": "^4.16.19"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240919.0",
+    "wrangler": "^4.40.2"
   }
 }

--- a/scripts/postbuild/prepare-worker-assets.mjs
+++ b/scripts/postbuild/prepare-worker-assets.mjs
@@ -1,0 +1,20 @@
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(here, '..', '..');
+const distClientDir = resolve(projectRoot, 'dist', 'client');
+const publicDir = resolve(projectRoot, 'public');
+
+if (!existsSync(distClientDir)) {
+  mkdirSync(distClientDir, { recursive: true });
+}
+
+if (existsSync(publicDir)) {
+  cpSync(publicDir, distClientDir, {
+    recursive: true,
+    force: false,
+    errorOnExist: false,
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "target": "ESNext",
-    "types": ["astro/client"],
+    "types": ["astro/client", "@cloudflare/workers-types"],
     "strict": true
   },
   "include": ["src"],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://developers.cloudflare.com/workers/tools/wrangler/configuration/schema.json",
+  "name": "astro-brochure-site",
+  "main": "./dist/_worker.js",
+  "compatibility_date": "2024-06-01",
+  "assets": {
+    "directory": "./dist/client",
+    "binding": "ASSETS"
+  },
+  "compatibility_flags": ["nodejs_compat"],
+  "build": {
+    "command": "npm run build"
+  }
+}


### PR DESCRIPTION
## Summary
- add a postbuild script that prepares the dist/client directory for Wrangler
- configure the Cloudflare Worker to use an ASSETS binding and nodejs compatibility flag
- document the deployment expectation and refresh Worker-related dependencies

## Testing
- npm install *(fails: registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cfa42bc08331974052f2743ac10b