### PR TITLE
Expose Decap OAuth handlers under /api routes

### DIFF
--- a/functions/api/decap/auth.ts
+++ b/functions/api/decap/auth.ts
@@ -1,0 +1,1 @@
+export { onRequest } from '../../decap/auth';

--- a/functions/api/decap/callback.ts
+++ b/functions/api/decap/callback.ts
@@ -1,0 +1,1 @@
+export { onRequest } from '../../decap/callback';

--- a/functions/decap/auth.ts
+++ b/functions/decap/auth.ts
@@ -1,0 +1,33 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+
+/**
+ * Cloudflare Pages Function to start the GitHub OAuth flow for Decap CMS.
+ */
+export const onRequest: PagesFunction = async ({ env, request }) => {
+  const clientId = env.GITHUB_CLIENT_ID as string | undefined;
+
+  if (!clientId) {
+    return new Response('Missing GitHub client ID configuration.', {
+      status: 500,
+      headers: { 'content-type': 'text/plain' },
+    });
+  }
+
+  try {
+    const requestUrl = new URL(request.url);
+    const redirectUri = new URL('/api/decap/callback', requestUrl.origin);
+
+    const authorizeUrl = new URL('https://github.com/login/oauth/authorize');
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('scope', 'repo');
+    authorizeUrl.searchParams.set('redirect_uri', redirectUri.toString());
+
+    return Response.redirect(authorizeUrl.toString(), 302);
+  } catch (error) {
+    console.error('Failed to generate GitHub authorization URL', error);
+    return new Response('Unable to initiate GitHub authorization.', {
+      status: 500,
+      headers: { 'content-type': 'text/plain' },
+    });
+  }
+};

--- a/functions/decap/callback.ts
+++ b/functions/decap/callback.ts
@@ -1,0 +1,98 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+
+/**
+ * Cloudflare Pages Function to complete the GitHub OAuth flow for Decap CMS.
+ */
+export const onRequest: PagesFunction = async ({ env, request }) => {
+  const clientId = env.GITHUB_CLIENT_ID as string | undefined;
+  const clientSecret = env.GITHUB_CLIENT_SECRET as string | undefined;
+
+  if (!clientId || !clientSecret) {
+    return new Response('Missing GitHub OAuth configuration.', {
+      status: 500,
+      headers: { 'content-type': 'text/plain' },
+    });
+  }
+
+  try {
+    const requestUrl = new URL(request.url);
+    const code = requestUrl.searchParams.get('code');
+
+    if (!code) {
+      return new Response('Missing authorization code.', {
+        status: 400,
+        headers: { 'content-type': 'text/plain' },
+      });
+    }
+
+    const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      console.error('GitHub token exchange failed with status', tokenResponse.status);
+      return new Response('Failed to exchange token with GitHub.', {
+        status: 502,
+        headers: { 'content-type': 'text/plain' },
+      });
+    }
+
+    const tokenJson: { access_token?: string; error?: string; error_description?: string } =
+      await tokenResponse.json();
+
+    if (!tokenJson.access_token) {
+      console.error('GitHub token exchange error', tokenJson);
+      const message = tokenJson.error_description || tokenJson.error || 'Unknown GitHub error.';
+      return new Response(`GitHub authorization failed: ${message}`, {
+        status: 502,
+        headers: { 'content-type': 'text/plain' },
+      });
+    }
+
+    const token = tokenJson.access_token;
+
+    const html = [
+      '<!DOCTYPE html>',
+      '<html lang="en">',
+      '  <head>',
+      '    <meta charset="utf-8" />',
+      '    <title>GitHub Authorization Success</title>',
+      '  </head>',
+      '  <body>',
+      '    <script>',
+      `      const token = ${JSON.stringify(token)};`,
+      "      try {",
+      "        window.opener.postMessage(",
+      "          'authorization:github:success:' + JSON.stringify({ token }),",
+      "          window.location.origin",
+      "        );",
+      "      } catch (error) {",
+      "        console.error('Failed to notify opener about authorization success', error);",
+      "      }",
+      "      window.close();",
+      '    </script>',
+      '  </body>',
+      '</html>',
+    ].join('\n');
+
+    return new Response(html, {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+  } catch (error) {
+    console.error('Unexpected error during GitHub OAuth callback', error);
+    return new Response('Unexpected error while completing authorization.', {
+      status: 500,
+      headers: { 'content-type': 'text/plain' },
+    });
+  }
+};

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,22 @@
+backend:
+  name: github
+  repo: YOUR_ORG/YOUR_REPO
+  branch: main
+  base_url: /api/decap
+  auth_endpoint: /auth
+media_folder: "public/uploads"
+public_folder: "/uploads"
+publish_mode: editorial_workflow
+collections:
+  - name: pages
+    label: Pages
+    folder: content/pages
+    create: true
+    slug: "{{slug}}"
+    extension: "md"
+    format: "frontmatter"
+    fields:
+      - { label: Title, name: title, widget: string }
+      - { label: Description, name: description, widget: text }
+      - { label: Hero Image, name: hero_image, widget: image, required: false }
+      - { label: Body, name: body, widget: markdown }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Decap CMS</title>
+  </head>
+  <body>
+    <!-- Load Decap CMS from the UNPKG CDN -->
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `/api/decap` entry points that reuse the existing Decap OAuth handlers so the CMS login no longer 404s

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6db44aef08331a10487d7933c49bf