### PR TITLE
Implement Decap OAuth routes using Astro APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Astro build artifacts
+.astro/

--- a/functions/api/decap/auth.ts
+++ b/functions/api/decap/auth.ts
@@ -1,1 +1,0 @@
-export { onRequest } from '../../decap/auth';

--- a/functions/api/decap/callback.ts
+++ b/functions/api/decap/callback.ts
@@ -1,1 +1,0 @@
-export { onRequest } from '../../decap/callback';

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  readonly GITHUB_CLIENT_ID?: string;
+  readonly GITHUB_CLIENT_SECRET?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/pages/api/decap/auth.ts
+++ b/src/pages/api/decap/auth.ts
@@ -1,10 +1,14 @@
-import type { PagesFunction } from '@cloudflare/workers-types';
+import type { APIContext, APIRoute } from 'astro';
 
-/**
- * Cloudflare Pages Function to start the GitHub OAuth flow for Decap CMS.
- */
-export const onRequest: PagesFunction = async ({ env, request }) => {
-  const clientId = env.GITHUB_CLIENT_ID as string | undefined;
+type RuntimeEnv = Record<string, string | undefined>;
+
+const getGithubClientId = (locals: APIContext['locals']): string | undefined => {
+  const runtimeEnv = locals.runtime?.env as RuntimeEnv | undefined;
+  return runtimeEnv?.GITHUB_CLIENT_ID ?? import.meta.env.GITHUB_CLIENT_ID;
+};
+
+export const GET: APIRoute = async ({ locals, request }) => {
+  const clientId = getGithubClientId(locals);
 
   if (!clientId) {
     return new Response('Missing GitHub client ID configuration.', {

--- a/src/pages/api/decap/callback.ts
+++ b/src/pages/api/decap/callback.ts
@@ -1,11 +1,25 @@
-import type { PagesFunction } from '@cloudflare/workers-types';
+import type { APIContext, APIRoute } from 'astro';
 
-/**
- * Cloudflare Pages Function to complete the GitHub OAuth flow for Decap CMS.
- */
-export const onRequest: PagesFunction = async ({ env, request }) => {
-  const clientId = env.GITHUB_CLIENT_ID as string | undefined;
-  const clientSecret = env.GITHUB_CLIENT_SECRET as string | undefined;
+type RuntimeEnv = Record<string, string | undefined>;
+
+type GithubTokenResponse = {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+};
+
+const getGithubCredentials = (
+  locals: APIContext['locals'],
+): { clientId?: string; clientSecret?: string } => {
+  const runtimeEnv = locals.runtime?.env as RuntimeEnv | undefined;
+  const clientId = runtimeEnv?.GITHUB_CLIENT_ID ?? import.meta.env.GITHUB_CLIENT_ID;
+  const clientSecret = runtimeEnv?.GITHUB_CLIENT_SECRET ?? import.meta.env.GITHUB_CLIENT_SECRET;
+
+  return { clientId, clientSecret };
+};
+
+export const GET: APIRoute = async ({ locals, request }) => {
+  const { clientId, clientSecret } = getGithubCredentials(locals);
 
   if (!clientId || !clientSecret) {
     return new Response('Missing GitHub OAuth configuration.', {
@@ -46,8 +60,7 @@ export const onRequest: PagesFunction = async ({ env, request }) => {
       });
     }
 
-    const tokenJson: { access_token?: string; error?: string; error_description?: string } =
-      await tokenResponse.json();
+    const tokenJson = (await tokenResponse.json()) as GithubTokenResponse;
 
     if (!tokenJson.access_token) {
       console.error('GitHub token exchange error', tokenJson);


### PR DESCRIPTION
## Summary
- add Astro API routes for Decap auth and callback that reuse the existing OAuth logic
- remove the legacy Cloudflare Pages Functions no longer needed after moving to Astro API routes
- document the required GitHub env vars and ignore Astro build artifacts for cleaner repos

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e31457988331a5902c771de08261