### PR TITLE
Include original state string in Decap OAuth callback payload

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -7,6 +7,34 @@
   </head>
   <body>
     <!-- Load Decap CMS from the UNPKG CDN -->
+    <script>
+      (function () {
+        const LOG_PREFIX = '[Decap OAuth]';
+        console.info(`${LOG_PREFIX} Waiting for GitHub authorization messages...`);
+
+        window.addEventListener('message', (event) => {
+          if (typeof event.data !== 'string') {
+            return;
+          }
+
+          if (event.data.startsWith('authorization:github:success:')) {
+            try {
+              const payloadText = event.data.substring('authorization:github:success:'.length);
+              const payload = JSON.parse(payloadText);
+              const { state, validatedState, ...rest } = payload;
+              console.info(
+                `${LOG_PREFIX} Received GitHub authorization payload.`,
+                rest,
+                state ? { state } : undefined,
+                validatedState ? { validatedState } : undefined,
+              );
+            } catch (parseError) {
+              console.error(`${LOG_PREFIX} Failed to parse GitHub authorization payload.`, parseError);
+            }
+          }
+        });
+      })();
+    </script>
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
   </body>
 </html>

--- a/src/pages/api/decap/auth.ts
+++ b/src/pages/api/decap/auth.ts
@@ -1,6 +1,26 @@
 import type { APIContext, APIRoute } from 'astro';
 
+const STATE_COOKIE_NAME = 'decap_oauth_state';
+const STATE_COOKIE_PATH = '/api/decap';
+const STATE_COOKIE_MAX_AGE_SECONDS = 5 * 60;
+
 type RuntimeEnv = Record<string, string | undefined>;
+
+const createStateCookie = (state: string, requestUrl: URL): string => {
+  const directives = [
+    `${STATE_COOKIE_NAME}=${encodeURIComponent(state)}`,
+    `Path=${STATE_COOKIE_PATH}`,
+    `Max-Age=${STATE_COOKIE_MAX_AGE_SECONDS}`,
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+
+  if (requestUrl.protocol === 'https:') {
+    directives.push('Secure');
+  }
+
+  return directives.join('; ');
+};
 
 const getGithubClientId = (locals: APIContext['locals']): string | undefined => {
   const runtimeEnv = locals.runtime?.env as RuntimeEnv | undefined;
@@ -20,6 +40,13 @@ export const GET: APIRoute = async ({ locals, request }) => {
   try {
     const requestUrl = new URL(request.url);
     const redirectUri = new URL('/api/decap/callback', requestUrl.origin);
+    const oauthState = crypto.randomUUID();
+    const clientState = requestUrl.searchParams.get('state');
+
+    const statePayload: Record<string, string> = { csrf: oauthState };
+    if (clientState) {
+      statePayload.payload = clientState;
+    }
 
     const authorizeUrl = new URL('https://github.com/login/oauth/authorize');
     authorizeUrl.searchParams.set('client_id', clientId);
@@ -28,13 +55,15 @@ export const GET: APIRoute = async ({ locals, request }) => {
       requestUrl.searchParams.get('scope') ?? 'repo',
     );
     authorizeUrl.searchParams.set('redirect_uri', redirectUri.toString());
+    authorizeUrl.searchParams.set('state', JSON.stringify(statePayload));
 
-    const state = requestUrl.searchParams.get('state');
-    if (state) {
-      authorizeUrl.searchParams.set('state', state);
-    }
+    const headers = new Headers({ Location: authorizeUrl.toString() });
+    headers.append('Set-Cookie', createStateCookie(oauthState, requestUrl));
 
-    return Response.redirect(authorizeUrl.toString(), 302);
+    return new Response(null, {
+      status: 302,
+      headers,
+    });
   } catch (error) {
     console.error('Failed to generate GitHub authorization URL', error);
     return new Response('Unable to initiate GitHub authorization.', {

--- a/src/pages/api/decap/callback.ts
+++ b/src/pages/api/decap/callback.ts
@@ -1,11 +1,68 @@
 import type { APIContext, APIRoute } from 'astro';
 
+const STATE_COOKIE_NAME = 'decap_oauth_state';
+const STATE_COOKIE_PATH = '/api/decap';
+
 type RuntimeEnv = Record<string, string | undefined>;
 
 type GithubTokenResponse = {
   access_token?: string;
   error?: string;
   error_description?: string;
+};
+
+type ParsedState = {
+  csrf: string;
+  payload?: string;
+};
+
+const parseCookies = (cookieHeader: string | null): Record<string, string> => {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return cookieHeader.split(';').reduce<Record<string, string>>((accumulator, cookie) => {
+    const [name, ...valueParts] = cookie.trim().split('=');
+    if (!name) {
+      return accumulator;
+    }
+
+    const value = valueParts.join('=');
+    accumulator[name] = value;
+    return accumulator;
+  }, {});
+};
+
+const parseAuthorizeState = (rawState: string): ParsedState => {
+  try {
+    const parsed = JSON.parse(rawState) as Partial<ParsedState>;
+    if (parsed && typeof parsed === 'object' && typeof parsed.csrf === 'string') {
+      return {
+        csrf: parsed.csrf,
+        payload: typeof parsed.payload === 'string' ? parsed.payload : undefined,
+      };
+    }
+  } catch (error) {
+    console.warn('Failed to parse OAuth state as JSON, falling back to raw value.', error);
+  }
+
+  return { csrf: rawState };
+};
+
+const createClearedStateCookie = (requestUrl: URL): string => {
+  const directives = [
+    `${STATE_COOKIE_NAME}=`,
+    `Path=${STATE_COOKIE_PATH}`,
+    'Max-Age=0',
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+
+  if (requestUrl.protocol === 'https:') {
+    directives.push('Secure');
+  }
+
+  return directives.join('; ');
 };
 
 const getGithubCredentials = (
@@ -31,7 +88,7 @@ export const GET: APIRoute = async ({ locals, request }) => {
   try {
     const requestUrl = new URL(request.url);
     const code = requestUrl.searchParams.get('code');
-    const state = requestUrl.searchParams.get('state');
+    const stateParam = requestUrl.searchParams.get('state');
 
     if (!code) {
       return new Response('Missing authorization code.', {
@@ -39,6 +96,52 @@ export const GET: APIRoute = async ({ locals, request }) => {
         headers: { 'content-type': 'text/plain' },
       });
     }
+
+    const cookies = parseCookies(request.headers.get('cookie'));
+    const storedStateValue = cookies[STATE_COOKIE_NAME];
+    const storedState = storedStateValue ? decodeURIComponent(storedStateValue) : undefined;
+
+    if (!storedState) {
+      console.error('OAuth callback received without a stored state cookie.');
+      const headers = new Headers({ 'content-type': 'text/plain' });
+      headers.append('Set-Cookie', createClearedStateCookie(requestUrl));
+      return new Response('Missing stored OAuth state.', {
+        status: 400,
+        headers,
+      });
+    }
+
+    if (!stateParam) {
+      console.error('OAuth callback missing state parameter.');
+      const headers = new Headers({ 'content-type': 'text/plain' });
+      headers.append('Set-Cookie', createClearedStateCookie(requestUrl));
+      return new Response('Missing OAuth state parameter.', {
+        status: 400,
+        headers,
+      });
+    }
+
+    const parsedState = parseAuthorizeState(stateParam);
+
+    if (storedState !== parsedState.csrf) {
+      console.error('OAuth state mismatch detected.', {
+        expected: storedState,
+        received: parsedState.csrf,
+      });
+      const headers = new Headers({ 'content-type': 'text/plain' });
+      headers.append('Set-Cookie', createClearedStateCookie(requestUrl));
+      return new Response('OAuth state mismatch detected.', {
+        status: 400,
+        headers,
+      });
+    }
+
+    const validatedState = parsedState.payload ?? null;
+
+    console.info('OAuth state validated successfully.', {
+      csrf: parsedState.csrf,
+      clientState: validatedState,
+    });
 
     const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
       method: 'POST',
@@ -55,9 +158,11 @@ export const GET: APIRoute = async ({ locals, request }) => {
 
     if (!tokenResponse.ok) {
       console.error('GitHub token exchange failed with status', tokenResponse.status);
+      const headers = new Headers({ 'content-type': 'text/plain' });
+      headers.append('Set-Cookie', createClearedStateCookie(requestUrl));
       return new Response('Failed to exchange token with GitHub.', {
         status: 502,
-        headers: { 'content-type': 'text/plain' },
+        headers,
       });
     }
 
@@ -66,20 +171,30 @@ export const GET: APIRoute = async ({ locals, request }) => {
     if (!tokenJson.access_token) {
       console.error('GitHub token exchange error', tokenJson);
       const message = tokenJson.error_description || tokenJson.error || 'Unknown GitHub error.';
+      const headers = new Headers({ 'content-type': 'text/plain' });
+      headers.append('Set-Cookie', createClearedStateCookie(requestUrl));
       return new Response(`GitHub authorization failed: ${message}`, {
         status: 502,
-        headers: { 'content-type': 'text/plain' },
+        headers,
       });
     }
 
     const token = tokenJson.access_token;
 
     const payload: Record<string, unknown> = { token };
-    if (state) {
-      payload.state = state;
+
+    if (stateParam) {
+      payload.state = stateParam;
+    }
+
+    if (validatedState) {
+      payload.validatedState = validatedState;
     }
 
     const payloadJson = JSON.stringify(payload);
+
+    const successHeaders = new Headers({ 'content-type': 'text/html' });
+    successHeaders.append('Set-Cookie', createClearedStateCookie(requestUrl));
 
     const html = [
       '<!DOCTYPE html>',
@@ -126,7 +241,7 @@ export const GET: APIRoute = async ({ locals, request }) => {
 
     return new Response(html, {
       status: 200,
-      headers: { 'content-type': 'text/html' },
+      headers: successHeaders,
     });
   } catch (error) {
     console.error('Unexpected error during GitHub OAuth callback', error);


### PR DESCRIPTION
## Summary
- preserve the original GitHub state string in the popup payload while still surfacing the validated client state separately
- enrich the Decap admin logging to show both the raw and validated OAuth state segments for easier troubleshooting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d701735a84833181e0b3cf56502eec